### PR TITLE
Fix bug with usage of _.defaults

### DIFF
--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -12,8 +12,8 @@ function Batch(options) {
 	this._entries = [];
 
 	// Allow the batch header/control defaults to be overriden if provided
-	this.header = options.header ? _.merge(options.header, require('./header'), _.defaults) : _.cloneDeep(require('./header'));
-	this.control = options.control ? _.merge(options.header, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
+	this.header = options.header ? _.defaultsDeep({}, options.header, require('./header')) : _.cloneDeep(require('./header'));
+	this.control = options.control ? _.defaultsDeep({}, options.control, require('./control')) : _.cloneDeep(require('./control'));
 
 	// Configure high-level overrides (these override the low-level settings if provided)
 	utils.overrideLowLevel(highLevelHeaderOverrides, options, this);

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -10,8 +10,8 @@ function File(options) {
 	this._batches = [];
 
 	// Allow the batch header/control defaults to be overriden if provided
-	this.header = options.header ? _.merge(options.header, require('./header')(), _.defaults) : require('./header')();
-	this.control = options.control ? _.merge(options.header, require('./control'), _.defaults) : _.cloneDeep(require('./control'));
+	this.header = options.header ? _.defaultsDeep({}, options.header, require('./header')()) : require('./header')();
+	this.control = options.control ? _.defaultsDeep({}, options.control, require('./control')) : _.cloneDeep(require('./control'));
 
 	// Configure high-level overrides (these override the low-level settings if provided)
 	utils.overrideLowLevel(highLevelOverrides, options, this);


### PR DESCRIPTION
Three issues here:
1. _.merge mutates its input, leading to this repo changing our config values when we passed them in
2. _.defaults is specified in the wrong order, so the defaults will override the settings passed by the user
3. the batch model uses the "header" settings for both batch and control